### PR TITLE
Fixed errors with submodules libzip and LibZipSharp

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -313,6 +313,10 @@ _prepare_submodules() {
                 xamarin-android-api-compatibility
                 xamarin-android-tools)
 
+    # For some reason these are not automatically added to external
+    git submodule add https://github.com/nih-at/libzip.git external/libzip
+    git submodule add https://github.com/xamarin/LibZipSharp.git external/LibZipSharp
+
     for Submodule in "${Submodules[@]}"; do
         git submodule init "external/${Submodule}"
         git config "submodule.external/${Submodule}.url" "${srcdir}/${Submodule}"


### PR DESCRIPTION
Without these additions the submodule preparation routine would fail with the following error:
error: pathspec 'external/LibZipSharp' did not match any file(s) known to git
or
error: pathspec 'external/libzip' did not match any file(s) known to git

I don't quite understand why these dependencies are not automatically copied over to external like all the other dependencies. I was unable to find any differences between the working dependencies and these in the PKGBUILD file.