### PR TITLE
Add support for Manjaro Linux

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -119,7 +119,8 @@ source=('git+https://github.com/xamarin/xamarin-android.git'
         "${_android_source[@]}"
         'https://dist.nuget.org/win-x86-commandline/v5.1.0/nuget.exe'
         Configuration.Override.props
-        xaprepare-arch.patch)
+        xaprepare-arch.patch
+        xaprepare-manjaro.patch)
 noextract=("${_android_source[@]##*/}")
 sha256sums=('SKIP'
             'SKIP'
@@ -193,7 +194,8 @@ sha256sums=('SKIP'
             '4070cbd35c7c8f868864f9d85cab19f8feb4f3982d846c509b9e210a6ec23457'
             '0ace4f53493332c9a75291ee96acd76b371b4e687175e4852bf85948176d7152'
             'c633ea19a84a5b638fb60d6421d8c2b10fdd6f1a5b455c4f0fe0fa0b0628878b'
-            '809792dbe7384634e82406b724c3f4f452af0c536f75bf115deb93aa682a7142')
+            '809792dbe7384634e82406b724c3f4f452af0c536f75bf115deb93aa682a7142'
+            '6a18361790a34a3992d881237d6a363e403b98811e7aeae0f9639bb8ec4626f3')
 
 if [ true = "${_include_proprietary}" ]; then
     pkgname=xamarin-android-proprietary-git
@@ -344,8 +346,9 @@ prepare() {
     mv "${srcdir}/nuget.exe" "${srcdir}/xamarin-android/.nuget/NuGet.exe"
     mv "${srcdir}/Configuration.Override.props" "${srcdir}/xamarin-android/"
 
-    # Add Arch Linux support to xaprepare.
+    # Add Arch Linux and Manjaro Linux support to xaprepare.
     git -C "${srcdir}/xamarin-android" apply "${srcdir}/xaprepare-arch.patch"
+    git -C "${srcdir}/xamarin-android" apply "${srcdir}/xaprepare-manjaro.patch"
 
     mkdir -p "${srcdir}/android-archives"
     AndroidSourceArchives=("${_android_source[@]##*/}")

--- a/xaprepare-manjaro.patch
+++ b/xaprepare-manjaro.patch
@@ -1,0 +1,12 @@
+diff --git a/build-tools/xaprepare/xaprepare/OperatingSystems/Linux.cs b/build-tools/xaprepare/xaprepare/OperatingSystems/Linux.cs
+index 1a2c7c07..41548ba0 100644
+--- a/build-tools/xaprepare/xaprepare/OperatingSystems/Linux.cs
++++ b/build-tools/xaprepare/xaprepare/OperatingSystems/Linux.cs
+@@ -33,6 +33,7 @@ and re-enable it after building with the following command:
+ 			{"Ubuntu",    (ctx) => new LinuxUbuntu (ctx)},
+ 			{"LinuxMint", (ctx) => new LinuxMint   (ctx)},
+ 			{"Arch",      (ctx) => new LinuxArch   (ctx)},
++			{"ManjaroLinux", (ctx) => new LinuxArch (ctx)},
+ 		};
+ 
+ 		bool warnBinFmt;


### PR DESCRIPTION
Manjaro Linux is based on Arch and at the moment it seems that the only restriction is that lsb_release returns ManjaroLinux instead of Arch. This allows Manjaro users to use this AUR package as well.